### PR TITLE
improve orphans detection when net connected to the same components

### DIFF
--- a/src/python_netlist/netlist.py
+++ b/src/python_netlist/netlist.py
@@ -25,12 +25,12 @@ class Netlist:
                 l = l.strip()
                 if '[' in l:
                     net_name = l.split()[1]
-                    net_conns = {}
+                    net_conns = []
                     i += 1
                     while len(txt[i]) > 4:
                         l = txt[i].strip()
                         tok = l.split()
-                        net_conns.update({tok[0]: tok[1]})
+                        net_conns.append({tok[0]: tok[1]})
                         i += 1
                     netlist.update({net_name: net_conns})
                 i += 1


### PR DESCRIPTION
seeing the component configuration, it's appear that the issued nets was connected only to the same component.

![image](https://user-images.githubusercontent.com/58881681/179997219-1f31d73d-d269-4370-acf9-1d4b270347e4.png)

﻿
In the .NET file generated by AD, the netlist is good => The issue is only in the script﻿

![image](https://user-images.githubusercontent.com/58881681/179997275-a68aed21-0f6c-41fa-a9a8-95be7f4f922a.png)
﻿
The issue append because we update a dict. So the net_conn U91AH:24 is replaced by U901AH:25


To resolve the issue, I changed net_conns by a list and use append instead of update ad you can see on the code diff.

@fdeprey @AbAzaanoun can you review ?